### PR TITLE
Fortify: update our GitHub Actions action versions

### DIFF
--- a/.github/workflows/fortify.yml
+++ b/.github/workflows/fortify.yml
@@ -16,14 +16,14 @@ jobs:
         java: [8, 11, 17]
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions/setup-java@v3
       with:
         distribution: temurin
         java-version: ${{matrix.java}}
         cache: sbt
 
-    - uses: actions/cache@v2
+    - uses: actions/cache@v3
       env:
         cache-name: fortify
       with:


### PR DESCRIPTION
GitHub is starting to complain they're outdated